### PR TITLE
fix bugs with charr literals delims [2]

### DIFF
--- a/source/LexicalAnalyzer/prepare.py
+++ b/source/LexicalAnalyzer/prepare.py
@@ -170,13 +170,13 @@ def get_charr(token):
     temp_token=''
     for i in range(len(token)):
         try:
-            if (token[i] in const.delimiters["charr_delim"] or token[i] in ['!','='] and token[i+1] == '=') and LexerCheck.is_Charr(temp_token):
+            if (token[i] in const.delimiters["charr_delim"] or (token[i] in ['!','='] and token[i+1] == '=')) and LexerCheck.is_Charr(temp_token):
                 token_cpy=token.replace(temp_token, '', 1)
                 return temp_token, token_cpy       
             else:
                 temp_token+=token[i]
         except IndexError:
-            return temp_token, token_cpy
+            temp_token += token[i]
     
 
 def remove_comments(code):

--- a/source/LexicalAnalyzer/prepare.py
+++ b/source/LexicalAnalyzer/prepare.py
@@ -168,12 +168,15 @@ class LexerCheck:
 def get_charr(token):
     token_cpy=''
     temp_token=''
-    for char in token:
-        if char in const.delimiters["txt_delim"] and LexerCheck.is_Charr(temp_token):
-            token_cpy=token.replace(temp_token, '', 1)
-            return temp_token, token_cpy       
-        else:
-            temp_token+=char
+    for i in range(len(token)):
+        try:
+            if (token[i] in const.delimiters["charr_delim"] or token[i] in ['!','='] and token[i+1] == '=') and LexerCheck.is_Charr(temp_token):
+                token_cpy=token.replace(temp_token, '', 1)
+                return temp_token, token_cpy       
+            else:
+                temp_token+=token[i]
+        except IndexError:
+            return temp_token, token_cpy
     
 
 def remove_comments(code):

--- a/source/LexicalAnalyzer/prepare.py
+++ b/source/LexicalAnalyzer/prepare.py
@@ -23,8 +23,13 @@ class LexerCheck:
             The total count of characters from the list found in the text.
         """
         count = 0
-        for char in text:
+        for i,char in enumerate(text):
             if char in char_list:
+                try:
+                    if text[i-1] == '\\':
+                        continue
+                except IndexError:
+                    pass
                 count += 1
         return count
     
@@ -329,6 +334,11 @@ def get_keyword(token):
                
         else:   
             temp_token+=char
+    # temporary solution
+    if temp_token in ["deins", "bet"]:
+        token_cpy=token.replace(temp_token, '', 1)
+        keyword_detected=True
+        return temp_token, token_cpy 
    
 def get_identifier(token):
     token_cpy=''
@@ -355,15 +365,16 @@ def get_operator(tokencode:str):
 
     if char==".": #isolated case for ...
         token+=char
-
-        if tokencode[position+1]==".":
-            token+=tokencode[position+1]
-            if tokencode[position+2]==".":
-                token+=tokencode[position+2]
-                if tokencode[position+3] in const.symbols_delims["..."]:
-                    token_cpy=tokencode.replace(token, '', 1)
-                    return token, token_cpy
-                
+        try:
+            if tokencode[position+1]==".":
+                token+=tokencode[position+1]
+                if tokencode[position+2]==".":
+                    token+=tokencode[position+2]
+                    if tokencode[position+3] in const.symbols_delims["..."]:
+                        token_cpy=tokencode.replace(token, '', 1)
+                        return token, token_cpy
+        except IndexError:
+            return None                
     elif char in const.single_symbols:
         token+=char
 

--- a/source/Sheesh# Compiler.py
+++ b/source/Sheesh# Compiler.py
@@ -105,29 +105,18 @@ def run_lex():
     tokens=compiler.lexer.tokens
     error=compiler.lexer.errors
     tokens=remove_eol(tokens)
-    # print(f"Lexer: {tokens}")
     if error:
-        print_lex(compiler.lexer.no_tokens)
-        print_error(error)
-        lex_table_pane.config(state="disabled")
-        error_pane.config(state="disabled")
-        return
+        tokens=remove_whitespace_type(tokens)
     elif tokens:
         tokens=remove_whitespace_type(tokens)
-        print_lex(tokens)
-        print_error(error)
-        lex_table_pane.config(state="disabled")
-        error_pane.config(state="disabled")
-        return
     else:
-        print_lex(compiler.lexer.no_tokens)
-        print_error(["Nothing to Lexically Analyze. Please input code."])
-        lex_table_pane.config(state="disabled")
-        error_pane.config(state="disabled")
-        return
-
-
-
+        tokens = compiler.lexer.no_tokens
+        error = ["Nothing to Lexically Analyze. Please input code."]
+    
+    print_lex(tokens)
+    print_error(error)
+    lex_table_pane.config(state="disabled")
+    error_pane.config(state="disabled")
 
 def remove_eol(tokens):
     new_tokens = []
@@ -142,7 +131,7 @@ def run_parser():
     print("Parsing...")
     code = txt_editor_pane.get("1.0", END)
     compiler=Compiler(code)
-    compiler.compile()
+    compiler.parse()
     # print_lex(remove_eol(tokens))
     lex_errors=compiler.lex_errors
     syntax_errors=compiler.syntax_errors

--- a/source/Sheesh# Compiler.py
+++ b/source/Sheesh# Compiler.py
@@ -1,6 +1,3 @@
-keywords = ["text", "charr","whole", "dec", "sus", "blank", "sheesh", "yeet", "based",
-            "kung", "ehkung", "deins", "when", "bet", "choose","for", "to", 
-            "step", "felloff", "pass", "use", "from", "nocap", "cap", "default", "up", "pa_mine", "def", "whilst"]
 # import source.helper as helper
 import sys
 sys.path.append( '.' )
@@ -9,6 +6,7 @@ from source.SyntaxAnalyzer.Parser import SyntaxAnalyzer as parser
 import customtkinter as ctk
 import tkinter as tk
 from tkinter import *
+from source.core.constants import keywords
 from PIL import Image, ImageTk
 from tkinter import constants
 from tkinter import ttk
@@ -107,22 +105,28 @@ def run_lex():
     tokens=compiler.lexer.tokens
     error=compiler.lexer.errors
     tokens=remove_eol(tokens)
-    if tokens:
-        tokens=remove_whitespace_type(tokens)
-        print_lex(tokens)
-        lex_table_pane.config(state="disabled")
-        error_pane.config(state="disabled")
-
+    # print(f"Lexer: {tokens}")
     if error:
         print_lex(compiler.lexer.no_tokens)
         print_error(error)
         lex_table_pane.config(state="disabled")
         error_pane.config(state="disabled")
+        return
+    elif tokens:
+        tokens=remove_whitespace_type(tokens)
+        print_lex(tokens)
+        print_error(error)
+        lex_table_pane.config(state="disabled")
+        error_pane.config(state="disabled")
+        return
     else:
         print_lex(compiler.lexer.no_tokens)
         print_error(["Nothing to Lexically Analyze. Please input code."])
         lex_table_pane.config(state="disabled")
         error_pane.config(state="disabled")
+        return
+
+
 
 
 def remove_eol(tokens):

--- a/source/core/compile.py
+++ b/source/core/compile.py
@@ -62,3 +62,16 @@ class Compiler:
         else:
             self.lex_errors=self.lexer.errors
             return
+
+    def parse(self):
+        print("Start Parsing...")
+        self.lexer.tokenize()
+        if not self.lexer.errors:
+            self.parser=SyntaxAnalyzer(
+                Compiler.remove_whitespace_type(self.lexer.tokens))
+            self.parser.parse()
+            if self.parser.syntax_errors:
+                self.syntax_errors=self.parser.syntax_errors
+        else:
+            self.lex_errors=self.lexer.errors
+    

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -3,7 +3,7 @@
 
 keywords = ["text", "charr","whole", "dec", "sus", "blank", "sheesh", "yeet", "based",
             "kung", "ehkung", "deins", "when", "bet", "choose","for", "to", #removed choice
-            "step", "felloff", "pass", "use", "from", "nocap", "cap", "default", "up", "pa_mine", "def", "whilst"] # added def and whilst     
+            "step", "felloff", "pass", "nocap", "cap", "default", "up", "pa_mine", "def", "whilst"] # added def and whilst     
 
 DATA_TYPES = ["text","charr", "whole", "dec", "sus", "blank"]
 valid_tokens = ["Keyword", "Identifier", "Dec", "Whole", "Symbol", "Operator", "Text", "Charr", "Sus", "Whitespace"]
@@ -68,26 +68,28 @@ delimiters = {
     "delim2": [" ","#"],
     "delim3": ["(", " "],
     "delim4": [" ","\\","{"],
-    "delim5": alph_num+[" ","(", "]", "["],
-    "delim6": alph_num+[" ", "(", "{", "\"", "\'"],             # added: (,{,",'}
+    "delim5": alph_num+[" ","("],
+    "delim6": alph_num+[" ", "(", "{", "\"", "\'"],             
     "delim7": [" ","\\","}", ""],
     "delim8": [" ","\\", ""],
-    "delim9": alph_num+[" ","(","{", "!", '"', '“', '"', '”', "\'"],           # added '
+    "delim9": alph_num+[" ","(","{", "!", '"', '“', '"', '”', "\'"],           
     "delim10": alph_all+[" ","(","!"],
     "delim11": alph_num+[" ","(","!", "\'"],
     "delim12": all_op+comma+[" ","#","[","]",")" ],
     "delim13": alph_num+[" ","\\","(", "{", "\"", None],
     "delim14": alph_all+comma+[" ","#", "}",None],
-    "delim15": alph_num+[" ", "!","(", ")", '"', '“', '"', '”', "-", "\'"],    # added '
-    "delim16": op+comma+[" ", "#", ")", "}", "{", ":", "]", "."], # added ] and : and .
+    "delim15": alph_num+[" ", "!","(", ")", '"', '“', '"', '”', "-", "\'"],    
+    "delim16": op+comma+[" ", "#", ")", "}", "{", ":", "]", "."], 
     "delim17": alph_num+[" ", '"', '“', '"', '”', "\\"],
-    "delim18": comma+[" ","#",")","|", "&","}"],                 # added delim18 for nocap and cap
+    "delim18": comma+[" ","#",")","|", "&","}"],                 
     "delim19": alph_num+[" ", "(", "\'"],
     "delim20": alph_num+[" ","\""],     
     "delim21": alph_num+op+comma+[" ","#","(",")","{","}","\"","\'"],
-    "delim22": [" ", ":","::"],                                 # added delim22 for default
-    "delim23": [" ", ")"],             # added delim23 for whole
-    "charr_delim": comma+[" ","#","=",")",":","::"],
+    "delim22": [" ", ":","::"],                                             # added delim22 for default
+    "delim23": [" ", ")"],                                                  
+    "delim24": alph_num+[" ","(", "]", "\'"],                               # added delim24 for '!=' 
+    "delim25": alph_num+[" ","(", "]", "]"],                                # added delim25 for '['    
+    "charr_delim": comma+[" ","#","==",")",":","::","!="],                  
     "txt_delim": comma+[" ", "#", ")", "}", ":", '=', ],
     "blk_delim": [" ", "\\",None],
     "id_delim": op+comma+[" ", "#", "(",")", "[", "]", "{", ".", ":"],
@@ -108,7 +110,6 @@ keywords_delims={
                 "ehkung":delimiters["delim3"],
                 "felloff":delimiters["delim2"],
                 "for":delimiters["delim3"],       
-                "from":delimiters["delim1"],  
                 "kung":delimiters["delim3"],  
                 "nocap":delimiters["delim18"], 
                 "pa_mine":delimiters["delim3"],
@@ -119,7 +120,6 @@ keywords_delims={
                 "text":delimiters["delim1"],  
                 "to":delimiters["delim1"],    
                 "up":delimiters["delim3"],    
-                "use":delimiters["delim1"],   
                 "when":delimiters["delim1"],  
                 "whole":delimiters["delim1"],
                 "whilst": delimiters["delim3"], 
@@ -145,12 +145,12 @@ symbols_delims={
                 "<":delimiters["delim5"],
                 "<=":delimiters["delim5"],
                 "!":delimiters["delim10"],
-                "!=":delimiters["delim5"],
+                "!=":delimiters["delim24"],
                 "&":delimiters["delim11"],
                 "|":delimiters["delim11"],
                 "...": ['"', '“', '"', '”'," ",]+alph_all, #added alph_all
 #------------------------------------- Symbols ------------------------------------------------------
-                "[":delimiters["delim5"],
+                "[":delimiters["delim25"],
                 "]":delimiters["delim12"],
                 "{":delimiters["delim13"],
                 "}":delimiters["delim14"],

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -89,7 +89,6 @@ delimiters = {
     "delim23": [" ", ")"],                                                  
     "delim24": alph_num+[" ","(", "]", "\'"],                               # added delim24 for '!=' 
     "delim25": alph_num+[" ","(", "]", "]"],                                # added delim25 for '['    
-    "delim26": [" ", None,"{"],                                # test bet and deins    
     "charr_delim": comma+[" ","#","==",")",":","::","!="],                  
     "txt_delim": comma+[" ", "#", ")", "}", ":", '=', ],
     "blk_delim": [" ", "\\",None],
@@ -99,7 +98,7 @@ delimiters = {
 }   
 keywords_delims={
                 "based":delimiters["delim1"],
-                "bet":delimiters["delim26"],   
+                "bet":delimiters["delim4"],   
                 "blank":delimiters["delim23"], 
                 "cap":delimiters["delim18"],   
                 "charr":delimiters["delim1"], 

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -53,8 +53,8 @@ other_symbols=["#", "::", ]
 all_symbols_nonop=grouping_symbols+other_symbols+[",", "."]
 invalid_id_char=op+comma+['#', '.', '@', '^', '&', '(', ')', '`', '~', ':', '?', '$', ';', '[', ']', '{', '}', '/', '\\', '`', '^', "'", '"', '“', '"', '”']
 invalid_text_char=[] #['"', '“', '"', '”', ]
-invalid_symbols=["@", "^", "&", "`", "~", "?", "$", ";", "'", '`',":"]
-multi_charr=[r"'\0'", r"'\n'", r"'\t'",]
+invalid_symbols=["@", "^", "&", "`", "~", "?", "$", ";", "'", '`',":", "\\"]
+multi_charr=[r"'\0'", r"'\n'", r"'\t'"]
 
 # Delimiters used in the Transition Diagram/DFA
 
@@ -89,6 +89,7 @@ delimiters = {
     "delim23": [" ", ")"],                                                  
     "delim24": alph_num+[" ","(", "]", "\'"],                               # added delim24 for '!=' 
     "delim25": alph_num+[" ","(", "]", "]"],                                # added delim25 for '['    
+    "delim26": [" ", None,"{"],                                # test bet and deins    
     "charr_delim": comma+[" ","#","==",")",":","::","!="],                  
     "txt_delim": comma+[" ", "#", ")", "}", ":", '=', ],
     "blk_delim": [" ", "\\",None],
@@ -98,7 +99,7 @@ delimiters = {
 }   
 keywords_delims={
                 "based":delimiters["delim1"],
-                "bet":delimiters["delim4"],   
+                "bet":delimiters["delim26"],   
                 "blank":delimiters["delim23"], 
                 "cap":delimiters["delim18"],   
                 "charr":delimiters["delim1"], 

--- a/source/core/error_handler.py
+++ b/source/core/error_handler.py
@@ -37,7 +37,7 @@ class LexError:
             errobj.toknum=symb.Token.tok_num
             
             return errobj
-        if tokencode[0:3]=="..." and i+4<len(tokencode) and tokencode[i+4] not in const.symbols_delims["..."]:
+        if tokencode[0:3]=="..." and i+3<len(tokencode) and tokencode[i+3] not in const.symbols_delims["..."]:
             buffer=tokencode[0:3]
             errobj.errorval=buffer
             errobj.remaining=tokencode.replace(buffer, '', 1)

--- a/source/core/error_handler.py
+++ b/source/core/error_handler.py
@@ -347,15 +347,15 @@ class LexError:
                 if tokencode[len(tokencode)-1]=="'":
                     errobj.errorval=tokencode[0:len(tokencode)-1]
                     errobj.remaining=tokencode.replace(buffer, '', 1)
-                    errobj.error_type=f"Invalid Null Delimiter for Charr '{buffer}', expected {const.delimiters['txt_delim']}"
+                    errobj.error_type=f"Invalid Null Delimiter for Charr '{buffer}', expected {const.delimiters['charr_delim']}"
                     errobj.line=symb.Token.line_num
                     errobj.toknum=symb.Token.tok_num
                     return errobj
                 elif buffer.startswith("'") and buffer.endswith("'"):
-                    if len(buffer)<len(tokencode) and prep.LexerCheck.is_Charr(buffer) and tokencode[i+1] not in const.delimiters["txt_delim"] :
+                    if len(buffer)<len(tokencode) and prep.LexerCheck.is_Charr(buffer) and tokencode[i+1] not in const.delimiters["charr_delim"] :
                         errobj.errorval=buffer
                         errobj.remaining=tokencode.replace(buffer, '', 1)
-                        errobj.error_type=f"Invalid Delimiter for Charr ({buffer}): [' {tokencode[i+1]} '], expected {const.delimiters['txt_delim']}"
+                        errobj.error_type=f"Invalid Delimiter for Charr ({buffer}): [' {tokencode[i+1]} '], expected {const.delimiters['charr_delim']}"
                         errobj.line=symb.Token.line_num
                         errobj.toknum=symb.Token.tok_num
                         return errobj


### PR DESCRIPTION
**CHANGES:**
- added delim24 for symbol '!='
- added delim25 for symbol '['
- fix bugs with _charr_ literal, for example:
`'A'!='A'` is a lexical error
- fixed gui issues when clicking the **LEX** button

**PS**: 
- When i try printing tokens during lexical analysis and clicking the **LEX**, the program crashes. Don't know what causes it to crash but just a thing to keep in mind. 
```
...
# in Sheesh# Compiler.py
def run_lex():
    
    print("Lexical Analysis...")
    code = txt_editor_pane.get("1.0", END)
    compiler=Compiler(code)
    compiler.compile()
    tokens=compiler.lexer.tokens
    error=compiler.lexer.errors
    tokens=remove_eol(tokens)
    print(f"Lexer: {tokens}") <----
    if error:
        print_lex(compiler.lexer.no_tokens)
        print_error(error)
        lex_table_pane.config(state="disabled")
     ...
```
- Lastly, before merging  the commits pala, pa-check if gumagana sa machine niyo properly yung mga charr errors. This commit may crash the program, lalo na galing sakin yung changes lmao. 